### PR TITLE
fix issue with webpack-cli and argument in wrong order

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "build": "webpack --config webpack.config.babel.js",
         "profile": "webpack --profile --json --config webpack.config.babel.js > ./dist/profile.json && webpack-bundle-analyzer ./dist/profile.json",
-        "start": "webpack --env mode=dev --env isDevServer --env NODE_ENV=local serve --config webpack.config.babel.js"
+        "start": "webpack serve --env mode=dev --env isDevServer --env NODE_ENV=local --config webpack.config.babel.js"
     },
     "husky": {
         "hooks": {
@@ -101,7 +101,7 @@
         "url-loader": "~4.1.1",
         "webpack": "~5.4.0",
         "webpack-bundle-analyzer": "~4.1.0",
-        "webpack-cli": "~4.2.0",
+        "webpack-cli": "~4.3.1",
         "webpack-dev-server": "~3.11.0",
         "webpack-merge": "~5.3.0",
         "yargs": "~16.1.0"


### PR DESCRIPTION
Hi!

Nice work, I tried it out and it gives me an error when running `npm run start` with the latest node and npm version (15.5.0) after looking at the error message `(node:50249) UnhandledPromiseRejectionWarning: TypeError: Class constructor ServeCommand cannot be invoked without 'new'` I looked at the webpack-cli repo and found [Error when run npm start: Class constructor ServeCommand cannot be invoked without 'new':](https://github.com/webpack/webpack-cli/issues/2272) which have reported the error. 

In short, the order needs to be: Syntax - `webpack [command] [options]` and the latest webpack needs to be 4.3.1.

Cheers!

