### PR TITLE
Add postcss to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "lint-staged": "~10.5.0",
         "mini-css-extract-plugin": "~1.3.0",
         "path": "~0.12.7",
+        "postcss": "~8.2.5",
         "postcss-loader": "~4.0.4",
         "prettier": "~2.1.2",
         "prettier-plugin-import-sort": "~0.0.6",


### PR DESCRIPTION
Fixes Error: 
Module build failed (from ../node_modules/postcss-loader/dist/cjs.js):
Error: PostCSS plugin autoprefixer requires PostCSS 8.